### PR TITLE
Bug fix in self.clients_to_wake_up.

### DIFF
--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -488,7 +488,8 @@ class Clock(object):
             self.registry[alarm_message.receiver] = registry
         registry.set_alarm(wakeup_time, alarm_message)
 
-        self.clients_to_wake_up[wakeup_time].append(alarm_message.receiver)
+        if alarm_message.receiver not in self.clients_to_wake_up[wakeup_time]:
+            self.clients_to_wake_up[wakeup_time].append(alarm_message.receiver)
 
     def list_alarms(self, receiver):
         """ returns alarms set for uuid

--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -434,7 +434,7 @@ class Clock(object):
         self._time = None
         self.registry = dict()
         self.alarm_time = []
-        self.clients_to_wake_up = defaultdict(list)
+        self.clients_to_wake_up = defaultdict(set)
         self.last_required_alarm = -1
 
     @property
@@ -488,8 +488,7 @@ class Clock(object):
             self.registry[alarm_message.receiver] = registry
         registry.set_alarm(wakeup_time, alarm_message)
 
-        if alarm_message.receiver not in self.clients_to_wake_up[wakeup_time]:
-            self.clients_to_wake_up[wakeup_time].append(alarm_message.receiver)
+        self.clients_to_wake_up[wakeup_time].add(alarm_message.receiver)
 
     def list_alarms(self, receiver):
         """ returns alarms set for uuid

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -376,12 +376,15 @@ def test_clear_alarms_by_topic():
     s.add(a)
     msg1 = TestMessage(sender=a, receiver=a, topic='1')
     msg2 = TestMessage(sender=a, receiver=a, topic='2')
+    msg3 = TestMessage(sender=a, receiver=a, topic='3')
     a.set_alarm(alarm_time=1, alarm_message=msg1, relative=True, ignore_alarm_if_idle=False)
     a.set_alarm(alarm_time=3, alarm_message=msg2, relative=True, ignore_alarm_if_idle=False)
+    a.set_alarm(alarm_time=1, alarm_message=msg3, relative=True, ignore_alarm_if_idle=False)
     assert s.clock.alarm_time == [1, 3]
     assert s.clock.clients_to_wake_up == {1: [a.uuid], 3: [a.uuid]}
     a.clear_alarms(receiver=a.uuid, topic='1')
-    assert s.clock.alarm_time == [3], s.clock.alarm_time
+    assert s.clock.alarm_time == [1, 3], s.clock.alarm_time
+    a.clear_alarms(receiver=None, topic='3')
     assert s.clock.list_alarms(a.uuid) == [(3, [msg2])]
     assert s.clock.clients_to_wake_up == {3: [a.uuid]}
 

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -381,12 +381,12 @@ def test_clear_alarms_by_topic():
     a.set_alarm(alarm_time=3, alarm_message=msg2, relative=True, ignore_alarm_if_idle=False)
     a.set_alarm(alarm_time=1, alarm_message=msg3, relative=True, ignore_alarm_if_idle=False)
     assert s.clock.alarm_time == [1, 3]
-    assert s.clock.clients_to_wake_up == {1: [a.uuid], 3: [a.uuid]}
+    assert s.clock.clients_to_wake_up == {1: {a.uuid}, 3: {a.uuid}}
     a.clear_alarms(receiver=a.uuid, topic='1')
     assert s.clock.alarm_time == [1, 3], s.clock.alarm_time
     a.clear_alarms(receiver=None, topic='3')
     assert s.clock.list_alarms(a.uuid) == [(3, [msg2])]
-    assert s.clock.clients_to_wake_up == {3: [a.uuid]}
+    assert s.clock.clients_to_wake_up == {3: {a.uuid}}
 
 
 def test_ping_pong_tests():


### PR DESCRIPTION
Previously, if two alarms were set for the same client at the same time (e.g. two different topics) the client would appear twice in the dictionary value of self.clients_to_wake_up as a result of being appended to the list. This would then become a problem when the alarm was cleared from the list as only one instance of the client in self.clients_to_wake_up would be deleted. The root cause is the unnecessary repetition of the client in this list which has now been prevented. Tests added into test_clear_alarms_by_topic.