### PR TITLE
run(seconds) aligned with Clock type of the Scheduler

### DIFF
--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -767,7 +767,8 @@ class Scheduler(object):
     def run(self, seconds=None, iterations=None, pause_if_idle=True, clear_alarms_at_end=True):
         """ The main 'run' operation of the Scheduler.
 
-        :param seconds: float, int, None: optional number of real-time seconds to run.
+        :param seconds: float, int, None: optional number of seconds to run. This is either real-time or simulation-time
+        seconds depending on which type of clock is being used.
         :param iterations: float, int, None: feature to let the scheduler run for
         N (`iterations`) updates before pausing.
         :param pause_if_idle: boolean: default=False: If no new messages are exchanged
@@ -781,7 +782,7 @@ class Scheduler(object):
         """
         start_time = None
         if isinstance(seconds, (int, float)) and seconds > 0:
-            start_time = time.time()
+            start_time = self.clock.time
 
         iterations_to_halt = None
         if isinstance(iterations, int) and iterations > 0:
@@ -821,7 +822,7 @@ class Scheduler(object):
 
             # determine whether to stop:
             if start_time is not None:
-                if time.time() >= (start_time + seconds):
+                if self.clock.time >= (start_time + seconds):
                     self._quit = True
 
             if iterations_to_halt is not None:

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -388,6 +388,30 @@ def test_clear_alarms_by_topic():
     assert s.clock.list_alarms(a.uuid) == [(3, [msg2])]
     assert s.clock.clients_to_wake_up == {3: {a.uuid}}
 
+def test_run_scheduler_until():
+    s = Scheduler(real_time=False)
+    a = TestAgent()
+    s.add(a)
+    msg1 = TestMessage(sender=a, receiver=a, topic='1')
+    msg2 = TestMessage(sender=a, receiver=a, topic='2')
+    msg3 = TestMessage(sender=a, receiver=a, topic='3')
+    a.set_alarm(alarm_time=1, alarm_message=msg1, relative=True, ignore_alarm_if_idle=False)
+    a.set_alarm(alarm_time=2, alarm_message=msg2, relative=True, ignore_alarm_if_idle=False)
+    a.set_alarm(alarm_time=3, alarm_message=msg3, relative=True, ignore_alarm_if_idle=False)
+    s.run(seconds=2)
+    assert s.clock.time == 2
+    assert s.clock.list_alarms(a.uuid) == [(3, [msg3])]
+
+    s = Scheduler(real_time=True)
+    a = TestAgent()
+    s.add(a)
+    msg1 = TestMessage(sender=a, receiver=a, topic='1')
+    start_time = time.time()
+    a.set_alarm(alarm_time=start_time + 10, alarm_message=msg1, relative=True, ignore_alarm_if_idle=False)
+    s.run(seconds=2)
+    end_time = time.time()
+    assert round(end_time - start_time, 0) == 2
+
 
 def test_ping_pong_tests():
     s = Scheduler()


### PR DESCRIPTION
This allows a Simulation to be run for a defined period of Simulation Time rather than a defined period of Real Time. Tests added. Perhaps it is too constrained? This assumes that a Scheduler with a Simulation Time clock would only ever be stopped according to it reaching a limit of Sim Time and not of Real Time. Thoughts?