### PR TITLE
Implement limit for tick() to guarantee Scheduler ends run at "seconds"

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -396,7 +396,20 @@ def test_run_scheduler_until():
     msg2 = TrialMessage(sender=a, receiver=a, topic='2')
     msg3 = TrialMessage(sender=a, receiver=a, topic='3')
     a.set_alarm(alarm_time=1, alarm_message=msg1, relative=True, ignore_alarm_if_idle=False)
-    a.set_alarm(alarm_time=2, alarm_message=msg2, relative=True, ignore_alarm_if_idle=False)
+    a.set_alarm(alarm_time=1.5, alarm_message=msg2, relative=True, ignore_alarm_if_idle=False)
+    a.set_alarm(alarm_time=3, alarm_message=msg3, relative=True, ignore_alarm_if_idle=False)
+    s.run()
+    assert s.clock.time == 3
+    assert not s.clock.list_alarms(a.uuid)
+
+    s = Scheduler(real_time=False)
+    a = TrialAgent()
+    s.add(a)
+    msg1 = TrialMessage(sender=a, receiver=a, topic='1')
+    msg2 = TrialMessage(sender=a, receiver=a, topic='2')
+    msg3 = TrialMessage(sender=a, receiver=a, topic='3')
+    a.set_alarm(alarm_time=1, alarm_message=msg1, relative=True, ignore_alarm_if_idle=False)
+    a.set_alarm(alarm_time=1.5, alarm_message=msg2, relative=True, ignore_alarm_if_idle=False)
     a.set_alarm(alarm_time=3, alarm_message=msg3, relative=True, ignore_alarm_if_idle=False)
     s.run(seconds=2)
     assert s.clock.time == 2


### PR DESCRIPTION
Previously tick() for SimulationClock would run to the next alarm time THEN check if self.time >= seconds before returning, so there was no guarantee that self.time was exactly equal to the expected run time. 

The previous tests didn't really capture this since there was an alarm set at the same time as the time limit.

The new tests, with alarms either side of the time limit, show more clearly how the limit works. 