### PR TITLE
Replace sets for repeatability

### DIFF
--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -586,12 +586,12 @@ class MailingList(object):
     def _add(self, a, b, c):
         """ insert helper """
         if c not in self.directory[b]:
-            self.directory[b][c] = set()
-        self.directory[b][c].add(a)
+            self.directory[b][c] = {}
+        self.directory[b][c][a] = True
 
     def _remove(self, a, b, c):
         """ cleanup helper """
-        self.directory[b][c].discard(a)
+        del self.directory[b][c][a]
         if not self.directory[b][c]:
             del self.directory[b][c]
         if not self.directory[b]:
@@ -653,13 +653,13 @@ class MailingList(object):
     def get_subscriber_list(self, target=None, topic=None):
         try:
             if target and topic:  # only retrieve subscribers of target on topic.
-                return self.directory[target][topic]
+                return list(self.directory[target][topic].keys())
             if target is not None:  # only retrieve subscribers of target ALL topics.
-                return {v for z in self.directory[target].values() for v in z}
+                return [v for z in self.directory[target].values() for v in z.keys()]
             if topic is not None:  # only retrieve subscribers of topic ALL agents.
-                return self.directory[topic][target]
+                return list(self.directory[topic][target].keys())
         except KeyError:
-            return set()
+            return []
 
     def get_mail_recipients(self, message):
         assert isinstance(message, AgentMessage)

--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -817,7 +817,7 @@ class Scheduler(object):
                 agent = self.agents[uuid]
                 agent.update()
                 if agent.keep_awake:
-                    self.has_keep_awake[uuid]=True
+                    self.has_keep_awake[uuid] = True
                 elif uuid in self.has_keep_awake:
                     del self.has_keep_awake[uuid]
             self.needs_update.clear()
@@ -937,4 +937,3 @@ class Scheduler(object):
 
     def get_subscriptions(self, subscriber):
         return self.mailing_lists.get_subscriptions(subscriber)
-

--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -435,7 +435,7 @@ class Clock(object):
         self._time = None
         self.registry = dict()
         self.alarm_time = []
-        self.clients_to_wake_up = defaultdict(set)
+        self.clients_to_wake_up = defaultdict(dict)
         self.last_required_alarm = -1
 
     @property
@@ -456,7 +456,7 @@ class Clock(object):
                 return
 
             list_of_messages = []
-            clients = self.clients_to_wake_up[timestamp]
+            clients = self.clients_to_wake_up[timestamp].keys()
             for client in clients:
                 registry = self.registry[client]
                 assert isinstance(registry, AlarmRegistry)
@@ -489,7 +489,7 @@ class Clock(object):
             self.registry[alarm_message.receiver] = registry
         registry.set_alarm(wakeup_time, alarm_message)
 
-        self.clients_to_wake_up[wakeup_time].add(alarm_message.receiver)
+        self.clients_to_wake_up[wakeup_time][alarm_message.receiver] = True
 
     def list_alarms(self, receiver):
         """ returns alarms set for uuid
@@ -514,7 +514,7 @@ class Clock(object):
             for timestamp in registry.alarms.copy():
                 registry.clear_alarms(timestamp, topic)
                 if not registry.has_alarm(timestamp):
-                    self.clients_to_wake_up[timestamp].remove(receiver)
+                    del self.clients_to_wake_up[timestamp][receiver]
 
                 if not self.clients_to_wake_up[timestamp]:
                     self.alarm_time.remove(timestamp)

--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -663,26 +663,27 @@ class MailingList(object):
 
     def get_mail_recipients(self, message):
         assert isinstance(message, AgentMessage)
-        recipients = set()
+        recipients = {}
 
         if message.receiver is None:  # it's a broadcast: Go to topic.
             pass
         else:  # it's a direct message.
             if None in self.directory[message.receiver]:  # the receiver exists as an agent.
                 # retrieve set of subscribers of messages send to this agent no matter the topic.
-                recipients.update(self.directory[message.receiver][None])
+                recipients.update({receiver: True for receiver in self.directory[message.receiver][None].keys()})
 
             if message.topic in self.directory[message.receiver]:  # there are subscribers who
                 # are interested only in the agent when it receives a message with a specific topic.
-                recipients.update(self.directory[message.receiver][message.topic])
+                recipients.update({receiver: True for receiver in
+                                   self.directory[message.receiver][message.topic].keys()})
 
         # Topic:
         if message.topic in self.directory:  # there are subscribers interested in this topic no
             # matter which agent is supposed to receive the message
             if None in self.directory[message.topic]:
-                recipients.update(self.directory[message.topic][None])
+                recipients.update({receiver: True for receiver in self.directory[message.topic][None].keys()})
 
-        return recipients
+        return recipients.keys()
 
 
 class Scheduler(object):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -174,7 +174,7 @@ def test_subscriptions():
     assert m.get_subscriber_list(topic='B') == []
 
     m.subscribe(4, 1, 'Z')
-    m.unsubscribe(4, everything=True)  # mailing list doesn't care, but scehduler will complain.
+    m.unsubscribe(4, everything=True)  # mailing list doesn't care, but scheduler will complain.
 
 
 def tests_add_to_scheduler():
@@ -215,8 +215,8 @@ def tests_add_to_scheduler():
     assert a.messages is False
     s.run()
     start = time.time()
-    alarm_mesage = TrialMessage(a, a)
-    a.set_alarm(alarm_time=1000000000, alarm_message=alarm_mesage)
+    alarm_message = TrialMessage(a, a)
+    a.set_alarm(alarm_time=1000000000, alarm_message=alarm_message)
     s.run()
     end = time.time()
     assert end - start < 1, "scheduler didn't ignore the setting drop alarm if idle."
@@ -448,7 +448,6 @@ def test_run_until_multiple_successive_runs():
     assert s.clock.time == 21
 
 
-
 def test_ping_pong_tests():
     s = Scheduler()
     limit = 5000
@@ -466,5 +465,3 @@ def test_ping_pong_tests():
     assert player_b.update_count == limit
     assert player_b.outcome != "won!"
     print(mps, "messages per second")
-
-

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -158,20 +158,20 @@ def test_subscriptions():
 
     m.subscribe(1, 1)
     m.subscribe(1, topic="A")
-    assert m.get_subscriber_list(target=1) == {1}
-    assert m.get_subscriber_list(topic='A') == {1}
+    assert m.get_subscriber_list(target=1) == [1]
+    assert m.get_subscriber_list(topic='A') == [1]
 
     m.subscribe(2, target=1, topic='B')
-    assert m.get_subscriber_list(target=1, topic='B') == {2}
+    assert m.get_subscriber_list(target=1, topic='B') == [2]
 
-    assert m.get_subscriber_list(target=1) == {1, 2}
+    assert m.get_subscriber_list(target=1) == [1, 2]
 
     m.subscribe(3, target=1)
-    assert m.get_subscriber_list(target=1) == {1, 2, 3}
+    assert m.get_subscriber_list(target=1) == [1, 3, 2]
 
-    assert m.get_subscriber_list(topic='A') == {1}
-    assert m.get_subscriber_list(topic='C') == set()
-    assert m.get_subscriber_list(topic='B') == set()
+    assert m.get_subscriber_list(topic='A') == [1]
+    assert m.get_subscriber_list(topic='C') == []
+    assert m.get_subscriber_list(topic='B') == []
 
     m.subscribe(4, 1, 'Z')
     m.unsubscribe(4, everything=True)  # mailing list doesn't care, but scehduler will complain.

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -381,12 +381,12 @@ def test_clear_alarms_by_topic():
     a.set_alarm(alarm_time=3, alarm_message=msg2, relative=True, ignore_alarm_if_idle=False)
     a.set_alarm(alarm_time=1, alarm_message=msg3, relative=True, ignore_alarm_if_idle=False)
     assert s.clock.alarm_time == [1, 3]
-    assert s.clock.clients_to_wake_up == {1: {a.uuid}, 3: {a.uuid}}
+    assert s.clock.clients_to_wake_up == {1: {a.uuid: True}, 3: {a.uuid: True}}
     a.clear_alarms(receiver=a.uuid, topic='1')
     assert s.clock.alarm_time == [1, 3], s.clock.alarm_time
     a.clear_alarms(receiver=None, topic='3')
     assert s.clock.list_alarms(a.uuid) == [(3, [msg2])]
-    assert s.clock.clients_to_wake_up == {3: {a.uuid}}
+    assert s.clock.clients_to_wake_up == {3: {a.uuid: True}}
 
 
 def test_run_scheduler_until():


### PR DESCRIPTION
Following yesterday's "fix" (spoiler: it didn't work). I traced the other instances of sets which could contribute to the Scheduler distributing the messages in a non-repeatable way. 

These were:
- the set used in get_mail_recipients in MailingList
- the set used in the defaultdict(dict) of MailingList.directory which is used in get_subscriber_list
- the set used in clients_to_wake_up in Clock which is used on release_alarm_messages

The remaining sets in MailingList.topics() and MailingList.subscriptions don't appear to be used in a way where non-repeatable orders will be problematic.