### PR TITLE
Feature extend subscription options

### DIFF
--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -576,26 +576,26 @@ class MailingList(object):
         if receiver, no topic: messages for receiver will be received.
         if topic, no receiver: message with said topic will be received.
         """
-        self._add(a=subscriber, b=receiver, c=topic)  # receiver registry:
-        self._add(a=subscriber, b=topic, c=receiver)  # topic registry
+        self._add(subscriber=subscriber, receiver=receiver, topic=topic)  # receiver registry:
+        self._add(subscriber=subscriber, receiver=topic, topic=receiver)  # topic registry
 
         if topic not in self.subscriptions[subscriber]:
             self.subscriptions[subscriber][topic] = set()
         self.subscriptions[subscriber][topic].add(receiver)
 
-    def _add(self, a, b, c):
+    def _add(self, subscriber, receiver, topic):
         """ insert helper """
-        if c not in self.directory[b]:
-            self.directory[b][c] = {}
-        self.directory[b][c][a] = True
+        if topic not in self.directory[receiver]:
+            self.directory[receiver][topic] = {}
+        self.directory[receiver][topic][subscriber] = True
 
-    def _remove(self, a, b, c):
+    def _remove(self, subscriber, receiver, topic):
         """ cleanup helper """
-        del self.directory[b][c][a]
-        if not self.directory[b][c]:
-            del self.directory[b][c]
-        if not self.directory[b]:
-            del self.directory[b]
+        del self.directory[receiver][topic][subscriber]
+        if not self.directory[receiver][topic]:
+            del self.directory[receiver][topic]
+        if not self.directory[receiver]:
+            del self.directory[receiver]
 
     def unsubscribe(self, subscriber, receiver=None, topic=None, everything=False):
         """

--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -635,10 +635,18 @@ class MailingList(object):
         assert isinstance(message, AgentMessage)
         recipients = {}
 
-        key_options = [message.sender, message.receiver, message.topic]
-
         # Generate all combinations
-        combinations = list(product(*[[val, None] for val in key_options]))
+        a, b, c = message.sender, message.receiver, message.topic
+
+        combinations = [
+            (a, None, None),
+            (None, b, None),
+            (None, None, c),
+            (a, b, None),
+            (a, None, c),
+            (None, b, c),
+            (a, b, c),
+        ]
 
         for key in combinations:
             if not any(key):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -119,7 +119,7 @@ def test_subscribe_and_unsubscribe():
     a.subscribe(c.uuid, 'fish')
     # We do not: a.subscribe(d, 'fish')
     a.subscribe(topic='quantum physics')
-    c.subscribe(target=a.uuid)
+    c.subscribe(receiver=a.uuid)
 
     assert a.get_subscriptions() == {  # topic, target_set
         None: {a.uuid},
@@ -141,7 +141,7 @@ def test_subscribe_and_unsubscribe():
     d3 = c.get_subscriptions()
     assert not d3  # d3 is empty.
 
-    c.subscribe(target=c.uuid)
+    c.subscribe(receiver=c.uuid)
     assert c.get_subscriptions() == {None: {c.uuid}}
 
     assert a.get_subscriptions() == {  # check that a's subscriptions are
@@ -158,16 +158,16 @@ def test_subscriptions():
 
     m.subscribe(1, 1)
     m.subscribe(1, topic="A")
-    assert m.get_subscriber_list(target=1) == [1]
+    assert m.get_subscriber_list(receiver=1) == [1]
     assert m.get_subscriber_list(topic='A') == [1]
 
-    m.subscribe(2, target=1, topic='B')
-    assert m.get_subscriber_list(target=1, topic='B') == [2]
+    m.subscribe(2, receiver=1, topic='B')
+    assert m.get_subscriber_list(receiver=1, topic='B') == [2]
 
-    assert m.get_subscriber_list(target=1) == [1, 2]
+    assert m.get_subscriber_list(receiver=1) == [1, 2]
 
-    m.subscribe(3, target=1)
-    assert m.get_subscriber_list(target=1) == [1, 3, 2]
+    m.subscribe(3, receiver=1)
+    assert m.get_subscriber_list(receiver=1) == [1, 3, 2]
 
     assert m.get_subscriber_list(topic='A') == [1]
     assert m.get_subscriber_list(topic='C') == []

--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -120,11 +120,11 @@
      "output_type": "stream",
      "text": [
       "Registering agent Agent 007\n",
-      "007 subscribing to 007 on all topics.\n",
-      "007 subscribing to Agent for all agents.\n",
+      "007 subscribing to msgs to 007 from all agents on all topics\n",
+      "007 subscribing to msgs on topic Agent from all agents to all agents\n",
       "Registering agent Agent 009\n",
-      "009 subscribing to 009 on all topics.\n",
-      "009 subscribing to Agent for all agents.\n"
+      "009 subscribing to msgs to 009 from all agents on all topics\n",
+      "009 subscribing to msgs on topic Agent from all agents to all agents\n"
      ]
     }
    ],
@@ -298,11 +298,11 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent 007\n",
-      "007 subscribing to 007 on all topics.\n",
-      "007 subscribing to TestAgent for all agents.\n",
+      "007 subscribing to msgs to 007 from all agents on all topics\n",
+      "007 subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent 009\n",
-      "009 subscribing to 009 on all topics.\n",
-      "009 subscribing to TestAgent for all agents.\n"
+      "009 subscribing to msgs to 009 from all agents on all topics\n",
+      "009 subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -470,11 +470,11 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent 007\n",
-      "007 subscribing to 007 on all topics.\n",
-      "007 subscribing to TestAgent for all agents.\n",
+      "007 subscribing to msgs to 007 from all agents on all topics\n",
+      "007 subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent 009\n",
-      "009 subscribing to 009 on all topics.\n",
-      "009 subscribing to TestAgent for all agents.\n"
+      "009 subscribing to msgs to 009 from all agents on all topics\n",
+      "009 subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -564,11 +564,11 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent 007\n",
-      "007 subscribing to 007 on all topics.\n",
-      "007 subscribing to TestAgent for all agents.\n",
+      "007 subscribing to msgs to 007 from all agents on all topics\n",
+      "007 subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent 009\n",
-      "009 subscribing to 009 on all topics.\n",
-      "009 subscribing to TestAgent for all agents.\n"
+      "009 subscribing to msgs to 009 from all agents on all topics\n",
+      "009 subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -761,11 +761,11 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent 007\n",
-      "007 subscribing to 007 on all topics.\n",
-      "007 subscribing to TestAgent for all agents.\n",
+      "007 subscribing to msgs to 007 from all agents on all topics\n",
+      "007 subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent 009\n",
-      "009 subscribing to 009 on all topics.\n",
-      "009 subscribing to TestAgent for all agents.\n"
+      "009 subscribing to msgs to 009 from all agents on all topics\n",
+      "009 subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -933,29 +933,29 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent A\n",
-      "A subscribing to A on all topics.\n",
-      "A subscribing to TestAgent for all agents.\n",
-      "A subscribing to 50 jokes you must know for all agents.\n",
+      "A subscribing to msgs to A from all agents on all topics\n",
+      "A subscribing to msgs on topic TestAgent from all agents to all agents\n",
+      "A subscribing to msgs on topic 50 jokes you must know from all agents to all agents\n",
       "Registering agent TestAgent B\n",
-      "B subscribing to B on all topics.\n",
-      "B subscribing to TestAgent for all agents.\n",
-      "B subscribing to 50 jokes you must know for all agents.\n",
+      "B subscribing to msgs to B from all agents on all topics\n",
+      "B subscribing to msgs on topic TestAgent from all agents to all agents\n",
+      "B subscribing to msgs on topic 50 jokes you must know from all agents to all agents\n",
       "Registering agent TestAgent C\n",
-      "C subscribing to C on all topics.\n",
-      "C subscribing to TestAgent for all agents.\n",
-      "C subscribing to 50 jokes you must know for all agents.\n",
+      "C subscribing to msgs to C from all agents on all topics\n",
+      "C subscribing to msgs on topic TestAgent from all agents to all agents\n",
+      "C subscribing to msgs on topic 50 jokes you must know from all agents to all agents\n",
       "Registering agent TestAgent D\n",
-      "D subscribing to D on all topics.\n",
-      "D subscribing to TestAgent for all agents.\n",
-      "D subscribing to 50 jokes you must know for all agents.\n",
+      "D subscribing to msgs to D from all agents on all topics\n",
+      "D subscribing to msgs on topic TestAgent from all agents to all agents\n",
+      "D subscribing to msgs on topic 50 jokes you must know from all agents to all agents\n",
       "Registering agent TestAgent E\n",
-      "E subscribing to E on all topics.\n",
-      "E subscribing to TestAgent for all agents.\n",
-      "E subscribing to 50 jokes you must know for all agents.\n",
+      "E subscribing to msgs to E from all agents on all topics\n",
+      "E subscribing to msgs on topic TestAgent from all agents to all agents\n",
+      "E subscribing to msgs on topic 50 jokes you must know from all agents to all agents\n",
       "Registering agent TestAgent F\n",
-      "F subscribing to F on all topics.\n",
-      "F subscribing to TestAgent for all agents.\n",
-      "F subscribing to 50 jokes you must know for all agents.\n"
+      "F subscribing to msgs to F from all agents on all topics\n",
+      "F subscribing to msgs on topic TestAgent from all agents to all agents\n",
+      "F subscribing to msgs on topic 50 jokes you must know from all agents to all agents\n"
      ]
     }
    ],
@@ -1059,17 +1059,17 @@
      "output_type": "stream",
      "text": [
       "Registering agent Agent A\n",
-      "A subscribing to A on all topics.\n",
-      "A subscribing to Agent for all agents.\n",
+      "A subscribing to msgs to A from all agents on all topics\n",
+      "A subscribing to msgs on topic Agent from all agents to all agents\n",
       "Registering agent TestAgent Basic\n",
-      "Basic subscribing to Basic on all topics.\n",
-      "Basic subscribing to TestAgent for all agents.\n",
-      "Basic subscribing to 50 jokes you must know for all agents.\n",
+      "Basic subscribing to msgs to Basic from all agents on all topics\n",
+      "Basic subscribing to msgs on topic TestAgent from all agents to all agents\n",
+      "Basic subscribing to msgs on topic 50 jokes you must know from all agents to all agents\n",
       "Registering agent PremiumTestAgent Premium\n",
-      "Premium subscribing to Premium on all topics.\n",
-      "Premium subscribing to PremiumTestAgent for all agents.\n",
-      "Premium subscribing to 50 jokes you must know for all agents.\n",
-      "Premium subscribing to Premium Joke for all agents.\n"
+      "Premium subscribing to msgs to Premium from all agents on all topics\n",
+      "Premium subscribing to msgs on topic PremiumTestAgent from all agents to all agents\n",
+      "Premium subscribing to msgs on topic 50 jokes you must know from all agents to all agents\n",
+      "Premium subscribing to msgs on topic Premium Joke from all agents to all agents\n"
      ]
     }
    ],
@@ -1201,15 +1201,15 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent 007\n",
-      "007 subscribing to 007 on all topics.\n",
-      "007 subscribing to TestAgent for all agents.\n",
+      "007 subscribing to msgs to 007 from all agents on all topics\n",
+      "007 subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent 009\n",
-      "009 subscribing to 009 on all topics.\n",
-      "009 subscribing to TestAgent for all agents.\n",
+      "009 subscribing to msgs to 009 from all agents on all topics\n",
+      "009 subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent BigBrother KGB\n",
-      "KGB subscribing to KGB on all topics.\n",
-      "KGB subscribing to BigBrother for all agents.\n",
-      "KGB subscribing to Joke for all agents.\n"
+      "KGB subscribing to msgs to KGB from all agents on all topics\n",
+      "KGB subscribing to msgs on topic BigBrother from all agents to all agents\n",
+      "KGB subscribing to msgs on topic Joke from all agents to all agents\n"
      ]
     }
    ],
@@ -1268,11 +1268,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "KGB subscribing to 007 on all topics.\n",
-      "KGB subscribing to 009 on all topics.\n",
+      "KGB subscribing to msgs to 007 from all agents on all topics\n",
+      "KGB subscribing to msgs to 009 from all agents on all topics\n",
       "Registering agent TestAgent PizzaPlace\n",
-      "PizzaPlace subscribing to PizzaPlace on all topics.\n",
-      "PizzaPlace subscribing to TestAgent for all agents.\n"
+      "PizzaPlace subscribing to msgs to PizzaPlace from all agents on all topics\n",
+      "PizzaPlace subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     },
     {
@@ -1296,7 +1296,7 @@
     "        return JunkMail(self.sender, self.receiver)\n",
     "\n",
     "for target in [agent_a, agent_b]:\n",
-    "    agent_c.subscribe(target=target.uuid)\n",
+    "    agent_c.subscribe(receiver=target.uuid)\n",
     "agent_c.operations[JunkMail.__name__] = agent_c.read\n",
     "\n",
     "pizza_place = TestAgent('PizzaPlace')\n",
@@ -1434,17 +1434,17 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent A\n",
-      "A subscribing to A on all topics.\n",
-      "A subscribing to TestAgent for all agents.\n",
+      "A subscribing to msgs to A from all agents on all topics\n",
+      "A subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent B\n",
-      "B subscribing to B on all topics.\n",
-      "B subscribing to TestAgent for all agents.\n",
+      "B subscribing to msgs to B from all agents on all topics\n",
+      "B subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent C\n",
-      "C subscribing to C on all topics.\n",
-      "C subscribing to TestAgent for all agents.\n",
+      "C subscribing to msgs to C from all agents on all topics\n",
+      "C subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent D\n",
-      "D subscribing to D on all topics.\n",
-      "D subscribing to TestAgent for all agents.\n"
+      "D subscribing to msgs to D from all agents on all topics\n",
+      "D subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -1673,7 +1673,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Thank you, I have received my $21 coupon, now I have 1 coupons\n"
+      "Thank you, I have received my $71 coupon, now I have 1 coupons\n"
      ]
     }
    ],
@@ -1768,20 +1768,20 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent A\n",
-      "A subscribing to A on all topics.\n",
-      "A subscribing to TestAgent for all agents.\n",
+      "A subscribing to msgs to A from all agents on all topics\n",
+      "A subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent B\n",
-      "B subscribing to B on all topics.\n",
-      "B subscribing to TestAgent for all agents.\n",
+      "B subscribing to msgs to B from all agents on all topics\n",
+      "B subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent C\n",
-      "C subscribing to C on all topics.\n",
-      "C subscribing to TestAgent for all agents.\n",
+      "C subscribing to msgs to C from all agents on all topics\n",
+      "C subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent D\n",
-      "D subscribing to D on all topics.\n",
-      "D subscribing to TestAgent for all agents.\n",
+      "D subscribing to msgs to D from all agents on all topics\n",
+      "D subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent E\n",
-      "E subscribing to E on all topics.\n",
-      "E subscribing to TestAgent for all agents.\n"
+      "E subscribing to msgs to E from all agents on all topics\n",
+      "E subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -1981,13 +1981,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent  D\n",
-      "Agent D receives alarm sent from E to D, created at 0, scheduled alarm time 3, decides to set 3 alarms\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 0, receiver is Agent B\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 0, receiver is Agent D\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 3, receiver is Agent D\n",
       "Agent  A\n",
-      "Agent A receives alarm sent from E to A, created at 0, scheduled alarm time 3, decides to set 0 alarms\n"
+      "Agent A receives alarm sent from E to A, created at 0, scheduled alarm time 3, decides to set 3 alarms\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 0, receiver is Agent B\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 0, receiver is Agent D\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 3, receiver is Agent D\n",
+      "Agent  D\n",
+      "Agent D receives alarm sent from E to D, created at 0, scheduled alarm time 3, decides to set 0 alarms\n"
      ]
     }
    ],
@@ -2035,12 +2035,12 @@
      "output_type": "stream",
      "text": [
       "Agent  B\n",
-      "Agent B receives alarm sent from D to B, created at 3, scheduled alarm time 0, decides to set 3 alarms\n",
+      "Agent B receives alarm sent from A to B, created at 3, scheduled alarm time 0, decides to set 3 alarms\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 5, receiver is Agent C\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 4, receiver is Agent B\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 2, receiver is Agent A\n",
       "Agent  D\n",
-      "Agent D receives alarm sent from D to D, created at 3, scheduled alarm time 0, decides to set 0 alarms\n"
+      "Agent D receives alarm sent from A to D, created at 3, scheduled alarm time 0, decides to set 0 alarms\n"
      ]
     }
    ],
@@ -2136,7 +2136,7 @@
      "output_type": "stream",
      "text": [
       "Agent  D\n",
-      "Agent D receives alarm sent from D to D, created at 3, scheduled alarm time 3, decides to set 0 alarms\n"
+      "Agent D receives alarm sent from A to D, created at 3, scheduled alarm time 3, decides to set 0 alarms\n"
      ]
     }
    ],
@@ -2385,20 +2385,20 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent A\n",
-      "A subscribing to A on all topics.\n",
-      "A subscribing to TestAgent for all agents.\n",
+      "A subscribing to msgs to A from all agents on all topics\n",
+      "A subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent B\n",
-      "B subscribing to B on all topics.\n",
-      "B subscribing to TestAgent for all agents.\n",
+      "B subscribing to msgs to B from all agents on all topics\n",
+      "B subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent C\n",
-      "C subscribing to C on all topics.\n",
-      "C subscribing to TestAgent for all agents.\n",
+      "C subscribing to msgs to C from all agents on all topics\n",
+      "C subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent D\n",
-      "D subscribing to D on all topics.\n",
-      "D subscribing to TestAgent for all agents.\n",
+      "D subscribing to msgs to D from all agents on all topics\n",
+      "D subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent E\n",
-      "E subscribing to E on all topics.\n",
-      "E subscribing to TestAgent for all agents.\n"
+      "E subscribing to msgs to E from all agents on all topics\n",
+      "E subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -2472,20 +2472,20 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent A\n",
-      "A subscribing to A on all topics.\n",
-      "A subscribing to TestAgent for all agents.\n",
+      "A subscribing to msgs to A from all agents on all topics\n",
+      "A subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent B\n",
-      "B subscribing to B on all topics.\n",
-      "B subscribing to TestAgent for all agents.\n",
+      "B subscribing to msgs to B from all agents on all topics\n",
+      "B subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent C\n",
-      "C subscribing to C on all topics.\n",
-      "C subscribing to TestAgent for all agents.\n",
+      "C subscribing to msgs to C from all agents on all topics\n",
+      "C subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent D\n",
-      "D subscribing to D on all topics.\n",
-      "D subscribing to TestAgent for all agents.\n",
+      "D subscribing to msgs to D from all agents on all topics\n",
+      "D subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent E\n",
-      "E subscribing to E on all topics.\n",
-      "E subscribing to TestAgent for all agents.\n"
+      "E subscribing to msgs to E from all agents on all topics\n",
+      "E subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -2518,11 +2518,11 @@
       "Agent E receives alarm sent from A to E, created at 0, scheduled alarm time 0, decides to set 2 alarms\n",
       "An alarm has been set by Agent E at t = 0, alarm time is 3, receiver is Agent A\n",
       "An alarm has been set by Agent E at t = 0, alarm time is 3, receiver is Agent D\n",
-      "Agent D receives alarm sent from E to D, created at 0, scheduled alarm time 3, decides to set 3 alarms\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 0, receiver is Agent B\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 0, receiver is Agent D\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 3, receiver is Agent D\n",
-      "Agent A receives alarm sent from E to A, created at 0, scheduled alarm time 3, decides to set 0 alarms\n"
+      "Agent A receives alarm sent from E to A, created at 0, scheduled alarm time 3, decides to set 3 alarms\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 0, receiver is Agent B\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 0, receiver is Agent D\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 3, receiver is Agent D\n",
+      "Agent D receives alarm sent from E to D, created at 0, scheduled alarm time 3, decides to set 0 alarms\n"
      ]
     }
    ],
@@ -2564,13 +2564,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent B receives alarm sent from D to B, created at 3, scheduled alarm time 0, decides to set 3 alarms\n",
+      "Agent B receives alarm sent from A to B, created at 3, scheduled alarm time 0, decides to set 3 alarms\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 5, receiver is Agent C\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 4, receiver is Agent B\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 2, receiver is Agent A\n",
-      "Agent D receives alarm sent from D to D, created at 3, scheduled alarm time 0, decides to set 0 alarms\n",
+      "Agent D receives alarm sent from A to D, created at 3, scheduled alarm time 0, decides to set 0 alarms\n",
       "Agent A receives alarm sent from B to A, created at 3, scheduled alarm time 2, decides to set 0 alarms\n",
-      "Agent D receives alarm sent from D to D, created at 3, scheduled alarm time 3, decides to set 0 alarms\n",
+      "Agent D receives alarm sent from A to D, created at 3, scheduled alarm time 3, decides to set 0 alarms\n",
       "Agent B receives alarm sent from B to B, created at 3, scheduled alarm time 4, decides to set 0 alarms\n",
       "Agent C receives alarm sent from B to C, created at 3, scheduled alarm time 5, decides to set 3 alarms\n",
       "An alarm has been set by Agent C at t = 8, alarm time is 3, receiver is Agent B\n",
@@ -2618,20 +2618,20 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent A\n",
-      "A subscribing to A on all topics.\n",
-      "A subscribing to TestAgent for all agents.\n",
+      "A subscribing to msgs to A from all agents on all topics\n",
+      "A subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent B\n",
-      "B subscribing to B on all topics.\n",
-      "B subscribing to TestAgent for all agents.\n",
+      "B subscribing to msgs to B from all agents on all topics\n",
+      "B subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent C\n",
-      "C subscribing to C on all topics.\n",
-      "C subscribing to TestAgent for all agents.\n",
+      "C subscribing to msgs to C from all agents on all topics\n",
+      "C subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent D\n",
-      "D subscribing to D on all topics.\n",
-      "D subscribing to TestAgent for all agents.\n",
+      "D subscribing to msgs to D from all agents on all topics\n",
+      "D subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent E\n",
-      "E subscribing to E on all topics.\n",
-      "E subscribing to TestAgent for all agents.\n"
+      "E subscribing to msgs to E from all agents on all topics\n",
+      "E subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -2685,18 +2685,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent D receives alarm sent from E to D, created at 0, scheduled alarm time 3, decides to set 3 alarms\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 0, receiver is Agent B\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 0, receiver is Agent D\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 3, receiver is Agent D\n",
-      "Agent A receives alarm sent from E to A, created at 0, scheduled alarm time 3, decides to set 0 alarms\n",
-      "Agent B receives alarm sent from D to B, created at 3, scheduled alarm time 0, decides to set 3 alarms\n",
+      "Agent A receives alarm sent from E to A, created at 0, scheduled alarm time 3, decides to set 3 alarms\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 0, receiver is Agent B\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 0, receiver is Agent D\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 3, receiver is Agent D\n",
+      "Agent D receives alarm sent from E to D, created at 0, scheduled alarm time 3, decides to set 0 alarms\n",
+      "Agent B receives alarm sent from A to B, created at 3, scheduled alarm time 0, decides to set 3 alarms\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 5, receiver is Agent C\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 4, receiver is Agent B\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 2, receiver is Agent A\n",
-      "Agent D receives alarm sent from D to D, created at 3, scheduled alarm time 0, decides to set 0 alarms\n",
+      "Agent D receives alarm sent from A to D, created at 3, scheduled alarm time 0, decides to set 0 alarms\n",
       "Agent A receives alarm sent from B to A, created at 3, scheduled alarm time 2, decides to set 0 alarms\n",
-      "Agent D receives alarm sent from D to D, created at 3, scheduled alarm time 3, decides to set 0 alarms\n",
+      "Agent D receives alarm sent from A to D, created at 3, scheduled alarm time 3, decides to set 0 alarms\n",
       "Agent B receives alarm sent from B to B, created at 3, scheduled alarm time 4, decides to set 0 alarms\n",
       "8\n"
      ]
@@ -2729,20 +2729,20 @@
      "output_type": "stream",
      "text": [
       "Registering agent TestAgent A\n",
-      "A subscribing to A on all topics.\n",
-      "A subscribing to TestAgent for all agents.\n",
+      "A subscribing to msgs to A from all agents on all topics\n",
+      "A subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent B\n",
-      "B subscribing to B on all topics.\n",
-      "B subscribing to TestAgent for all agents.\n",
+      "B subscribing to msgs to B from all agents on all topics\n",
+      "B subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent C\n",
-      "C subscribing to C on all topics.\n",
-      "C subscribing to TestAgent for all agents.\n",
+      "C subscribing to msgs to C from all agents on all topics\n",
+      "C subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent D\n",
-      "D subscribing to D on all topics.\n",
-      "D subscribing to TestAgent for all agents.\n",
+      "D subscribing to msgs to D from all agents on all topics\n",
+      "D subscribing to msgs on topic TestAgent from all agents to all agents\n",
       "Registering agent TestAgent E\n",
-      "E subscribing to E on all topics.\n",
-      "E subscribing to TestAgent for all agents.\n"
+      "E subscribing to msgs to E from all agents on all topics\n",
+      "E subscribing to msgs on topic TestAgent from all agents to all agents\n"
      ]
     }
    ],
@@ -2770,18 +2770,18 @@
       "Agent E receives alarm sent from A to E, created at 0, scheduled alarm time 0, decides to set 2 alarms\n",
       "An alarm has been set by Agent E at t = 0, alarm time is 3, receiver is Agent A\n",
       "An alarm has been set by Agent E at t = 0, alarm time is 3, receiver is Agent D\n",
-      "Agent D receives alarm sent from E to D, created at 0, scheduled alarm time 3, decides to set 3 alarms\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 0, receiver is Agent B\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 0, receiver is Agent D\n",
-      "An alarm has been set by Agent D at t = 3, alarm time is 3, receiver is Agent D\n",
-      "Agent A receives alarm sent from E to A, created at 0, scheduled alarm time 3, decides to set 0 alarms\n",
-      "Agent B receives alarm sent from D to B, created at 3, scheduled alarm time 0, decides to set 3 alarms\n",
+      "Agent A receives alarm sent from E to A, created at 0, scheduled alarm time 3, decides to set 3 alarms\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 0, receiver is Agent B\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 0, receiver is Agent D\n",
+      "An alarm has been set by Agent A at t = 3, alarm time is 3, receiver is Agent D\n",
+      "Agent D receives alarm sent from E to D, created at 0, scheduled alarm time 3, decides to set 0 alarms\n",
+      "Agent B receives alarm sent from A to B, created at 3, scheduled alarm time 0, decides to set 3 alarms\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 5, receiver is Agent C\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 4, receiver is Agent B\n",
       "An alarm has been set by Agent B at t = 3, alarm time is 2, receiver is Agent A\n",
-      "Agent D receives alarm sent from D to D, created at 3, scheduled alarm time 0, decides to set 0 alarms\n",
+      "Agent D receives alarm sent from A to D, created at 3, scheduled alarm time 0, decides to set 0 alarms\n",
       "Agent A receives alarm sent from B to A, created at 3, scheduled alarm time 2, decides to set 0 alarms\n",
-      "Agent D receives alarm sent from D to D, created at 3, scheduled alarm time 3, decides to set 0 alarms\n",
+      "Agent D receives alarm sent from A to D, created at 3, scheduled alarm time 3, decides to set 0 alarms\n",
       "Agent B receives alarm sent from B to B, created at 3, scheduled alarm time 4, decides to set 0 alarms\n",
       "Agent C receives alarm sent from B to C, created at 3, scheduled alarm time 5, decides to set 3 alarms\n",
       "An alarm has been set by Agent C at t = 8, alarm time is 3, receiver is Agent B\n",


### PR DESCRIPTION
MailingList.directory is now a defaultdict(list) with a triple for it's key in the format (sender, receiver, topic) where None is used if no value is given during subscription. So subscribing to a receiver only for agent_uuid=2 (this used to be called "target") would result in a (None, 2, None) as the key followed by the subscriber being appended to the list as the value. 

get_mail_recipients produces all combinations of (sender, receiver, topic) and looks for values in the directory to return as recipients. 

As has been noted, this is a breaking change in that the .subscribe(), .unsubscribe() and .get_subscriber_list() APIs have now changed. Furthermore, the return format in get_subscriptions() has also changed. 