### PR TITLE
Feature second attempt extend subscription options

### DIFF
--- a/maslite/version.py
+++ b/maslite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 5
+major, minor, patch = 2023, 0, 0
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)


### PR DESCRIPTION
MailingList updated so that self.directory is now a nested dict (3 deep). The first key is "sender", the second key is "receiver" and the third key is "topic". get_mail_recipients can now make use of dictionary lookups to extract the subscribers. 

For example:
self.directory[None][None]["Bananas"] would return the subscribers who are subscribed to the topic of "Bananas"
self.directory[Monkey_1][Monkey_2]["Bananas"] would return the subscribers who are subscribed to the very specific instance of Monkey_1 sending "Bananas" to Monkey_2.