### PR TITLE
Issue 17 throughput benchmarks

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -29,9 +29,9 @@ if __name__ == "__main__":
     s.run(seconds=10)
     print(f"{m.value/10:,} messages/second")
 
-    # :~$ python3.10 benchmarks.py
-    # 340,283.8 messages/second
+    # :~$ python3.9 benchmarks.py
+    # 480,440.9 messages/second
 
     # :-$ pypy3 benchmarks.py
-    # 2,975,577.7 messages/second
+    # 6,441,251.9 messages/second
     

--- a/maslite/__init__.py
+++ b/maslite/__init__.py
@@ -643,7 +643,9 @@ class MailingList(object):
         if everything: all subscriptions are removed.
         else: only the subscription with the given sender, receiver and topic is removed.
         """
-        if subscriber not in self.subscriptions: raise ValueError(f"subscriber {subscriber} unknown.")
+        if subscriber not in self.subscriptions:
+            # The subscriber was never subscribed to anything in the first place - which is completely valid!
+            return
         if everything is False and sender is None and receiver is None and topic is None: raise ValueError("please read the docstring. ")
 
         if everything:
@@ -666,10 +668,14 @@ class MailingList(object):
 
     def get_mail_recipients(self, message):
         assert isinstance(message, AgentMessage)
-        recipients = {}
 
         # Generate all combinations
         sender, receiver, topic = message.sender, message.receiver, message.topic
+
+        if receiver is None:
+            recipients = {}
+        else:
+            recipients = {receiver: True}
 
         if sender in self.directory:
             sender_dict = self.directory[sender]
@@ -751,8 +757,6 @@ class Scheduler(object):
         agent._scheduler_api = self
         agent._clock = self.clock
 
-        self.subscribe(subscriber=agent.uuid, receiver=agent.uuid, topic=None)
-        self.subscribe(subscriber=agent.uuid, receiver=None, topic=agent.__class__.__name__)
         agent.setup()
 
         if agent.keep_awake:

--- a/maslite/version.py
+++ b/maslite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 0, 0
+major, minor, patch = 2023, 1, 0
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -121,18 +121,13 @@ def test_subscribe_and_unsubscribe():
     a.subscribe(topic='quantum physics')
     c.subscribe(receiver=a.uuid)
 
-    assert a.get_subscriptions() == {None: {a.uuid: {None: True},
-                                            None: {"Agent": True,
-                                                   "quantum physics": True},
+    assert a.get_subscriptions() == {None: {None: {"quantum physics": True},
                                             b.uuid: {"fish": True},
                                             c.uuid: {"fish": True}}}
 
-    assert b.get_subscriptions() == {None: {b.uuid: {None: True},
-                                            None: {"Agent": True}}}
+    assert b.get_subscriptions() == {}
 
-    assert c.get_subscriptions() == {None: {c.uuid: {None: True},
-                                            None: {"Agent": True},
-                                            a.uuid: {None: True}}}
+    assert c.get_subscriptions() == {None: {a.uuid: {None: True}}}
 
     c.unsubscribe(everything=True)
     d3 = c.get_subscriptions()
@@ -141,9 +136,7 @@ def test_subscribe_and_unsubscribe():
     c.subscribe(receiver=c.uuid)
     assert c.get_subscriptions() == {None: {c.uuid: {None: True}}}
 
-    assert a.get_subscriptions() == {None: {a.uuid: {None: True},
-                                            None: {"Agent": True,
-                                                   "quantum physics": True},
+    assert a.get_subscriptions() == {None: {None: {"quantum physics": True},
                                             b.uuid: {"fish": True},
                                             c.uuid: {"fish": True}}}
 
@@ -169,7 +162,9 @@ def test_subscriptions():
     assert m.get_subscriber_list(topic='B') == []
 
     m.subscribe(subscriber=4, receiver=1, topic='Z')
+    assert m.get_subscriber_list(receiver=1, topic='Z') == [4]
     m.unsubscribe(4, everything=True)  # mailing list doesn't care, but scheduler will complain.
+    assert m.get_subscriber_list(receiver=1, topic='Z') == []
 
 
 def test_message_and_broadcast_subscriptions():
@@ -261,15 +256,6 @@ def tests_add_to_scheduler():
     assert a.count_setups == 1
     assert a.get_subscription_topics() == s.get_subscription_topics(), "these should be the same"
 
-    assert a.uuid in a.get_subscription_topics()
-    assert a.__class__.__name__ in a.get_subscription_topics()
-    a.unsubscribe(topic=a.__class__.__name__)
-    assert a.uuid in a.get_subscription_topics()
-    assert a.__class__.__name__ not in a.get_subscription_topics()
-    assert a.uuid in a.get_subscriber_list(receiver=a.uuid)
-    a.subscribe(topic=a.__class__.__name__)
-    assert a.__class__.__name__ in a.get_subscription_topics()
-
     assert a.messages is False
     m = TrialMessage(sender=a, receiver=a)
     assert m.sender == a.uuid
@@ -313,7 +299,6 @@ def tests_add_to_scheduler():
     b = TrialAgent()
     a.add(b)
     assert b.uuid in s.agents
-    assert b.uuid in a.get_subscription_topics()
 
     try:
         a.add(b)
@@ -323,7 +308,6 @@ def tests_add_to_scheduler():
 
     a.remove(b.uuid)
     assert b.uuid not in s.agents
-    assert b.uuid not in a.get_subscription_topics()
     a.add(b)
 
     s.run()


### PR DESCRIPTION
In order to improve the performance of the message distribution (with a focus on the get_mail_recipients function which profiling indicated as being responsible for ~15% of run time) the following updates have been made:

1. Agents no longer subscribe to themselves and their class when they are added to the scheduler. The first part of this (agents subscribing to themselves) allowed the handling of direct messages to be combined with the handling of subscription distribution. This, however, is inefficient in systems where direct messages account for the majority of messages as it requires the subscription directory to be fetched when message.receiver could be used instead. The second part of this (subscribing to their class) was a case of the scheduler interfering where it didn't need to. If a user wants to add subscriptions to the system, they can, but they shouldn't happen automatically. By not doing this we reduce the number of subscribers in the subscription directory.
2. "direct" argument has been added to AgentMessage. When the direct bool is set to True, this message is exempt from subscriber checks. This allows us to avoid fetching the nested dicts entirely and skip that process. NOTE: it is important to use this with caution, only for messages which are known to the user to never be subject to subscription. 

Profiling of these changes (using python 3.9) indicate that the Scheduler is capable of distributing an additional 100,000 msgs/second.